### PR TITLE
🐛 Fix check for non-public keys

### DIFF
--- a/src/OpenCrypto.js
+++ b/src/OpenCrypto.js
@@ -590,7 +590,7 @@ export default class OpenCrypto {
     const self = this
 
     return new Promise((resolve, reject) => {
-      if (Object.prototype.toString.call(publicKey) !== '[object CryptoKey]' && publicKey.type !== 'public') {
+      if (Object.prototype.toString.call(publicKey) !== '[object CryptoKey]' || publicKey.type !== 'public') {
         throw new TypeError('Expected input of publicKey to be a CryptoKey Object of type public')
       }
 


### PR DESCRIPTION
The existing check && check means it will only check the key.type parameter on things that are NOT crypto keys. This flips the logic operator to a disjunction to look for things that either are not crypto keys or are crypto keys that are not public